### PR TITLE
write used the wrong char count

### DIFF
--- a/main.c
+++ b/main.c
@@ -821,7 +821,7 @@ void termination_signal_handler (int signum) {
     rl_cleanup_after_signal ();
   }
   
-  if (write (1, "SIGNAL received\n", 18) < 0) { 
+  if (write (1, "SIGNAL received\n", 16) < 0) { 
     // Sad thing
   }
  


### PR DESCRIPTION
fixes this error:

main.c:824:7: error: ‘write’ reading 18 bytes from a region of size 17 [-Werror=stringop-overread]
  824 |   if (write (1, "SIGNAL received\n", 18) < 0) {

the string is 16 chars long (including the \n but excluding the \0, that is included in that 17 of the error message)